### PR TITLE
improve default getExpectedIn

### DIFF
--- a/scripts/config_eth.ts
+++ b/scripts/config_eth.ts
@@ -157,7 +157,7 @@ export const EthConfig: Record<string, IConfig> = {
 
     tokens: [{symbol: 'dai', address: '0xad6d458402f60fd3bd25163575031acdce07538d'}],
 
-    wNative: '0x0a180a76e4466bf68a7f86fb029bed3cccfaaac5',
+    wNative: '0xc778417e063141139fce010982780140aa0cd5ab',
 
     // Uniswap & clones
     uniswap: {


### PR DESCRIPTION
This is a slight improvement. Apperently the name `lastSrcAmount` is misleading, it should be `lastGoodSrcAmount`. And we only update this value when the call to `getExpectedReturn` succeed. Upon error, we should try to take a value closer to this value.
Also added a final `getExpectedReturn` call, because the last updated srcAmount value is not checked.
These changes 'theoretically' should cover more cases.