### PR TITLE
Add priceImpact and improve univ3 getAmountIn

### DIFF
--- a/contracts.json
+++ b/contracts.json
@@ -71,15 +71,15 @@
     "lendingContracts": {}
   },
   "eth_ropsten": {
-    "smartWalletImplementation": "0x2ce6E029f52da66c95682541F3c230c28E72dF14",
+    "smartWalletImplementation": "0x899c3a16186087d393DfAA60BbeEf757b37268F7",
     "smartWalletProxy": "0xf351Dd5EC89e5ac6c9125262853c74E714C1d56a",
     "fetchTokenBalances": "0xA526388721De4cB8206ff4D0b1A1948696b5d073",
     "fetchAaveDataWrapper": "0xD7eA9048908F5E19DCcdD9623dc820feDbb54D45",
     "swapContracts": {
-      "uniSwap": "0x6deaAe9d76991db2943064Bca84e00f63c46C0A3",
-      "uniSwapV3": "0x5bDc55f24167361853f75aC6B307703599F81a08",
-      "kyberProxy": "0x151f954485DC1B72F85F21a17219E374f7de5D8c",
-      "kyberDmm": "0xf51d888bc316595ca8eB77dBf4d86480F2b4ae9a"
+      "uniSwap": "0xfd5904626c103A9bE91635DF823B442f0b77EC88",
+      "uniSwapV3": "0x0993A84E5bdad44f2Cb49C8eB8CEC81Bc8791d6B",
+      "kyberProxy": "0xF484d5D60e80cF75E5369EbFCc102CD04965F63e",
+      "kyberDmm": "0x670667eab359030aF7c6f785FC32c25BbE9a7a31"
     },
     "lendingContracts": {
       "compoundLending": "0x60fc810EA972809d729FCE0043B82a58766596ee"

--- a/contracts/SmartWalletImplementation.sol
+++ b/contracts/SmartWalletImplementation.sol
@@ -275,8 +275,7 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             destAmount,
             params.feeMode,
             params.feeBps,
-            params.platformWallet,
-            params.extraArgs
+            params.platformWallet
         );
     }
 
@@ -335,8 +334,7 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             destAmount,
             params.feeMode,
             params.feeBps,
-            params.platformWallet,
-            params.extraArgs
+            params.platformWallet
         );
     }
 
@@ -428,15 +426,13 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             abi.encodePacked(params.rateMode)
         );
 
-        {
-            uint256 actualDebtPaid = debt.sub(
-                ILending(params.lendingContract).getUserDebtCurrent(
-                    params.tradePath[params.tradePath.length - 1],
-                    msg.sender
-                )
-            );
-            require(actualDebtPaid >= actualPayAmount, "low paid amount");
-        }
+        uint256 actualDebtPaid = debt.sub(
+            ILending(params.lendingContract).getUserDebtCurrent(
+                params.tradePath[params.tradePath.length - 1],
+                msg.sender
+            )
+        );
+        require(actualDebtPaid >= actualPayAmount, "low paid amount");
 
         emit SwapAndRepay(
             msg.sender,
@@ -448,8 +444,7 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             actualPayAmount,
             params.feeMode,
             params.feeBps,
-            params.platformWallet,
-            params.extraArgs
+            params.platformWallet
         );
     }
 

--- a/contracts/SmartWalletImplementation.sol
+++ b/contracts/SmartWalletImplementation.sol
@@ -275,7 +275,8 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             destAmount,
             params.feeMode,
             params.feeBps,
-            params.platformWallet
+            params.platformWallet,
+            params.extraArgs
         );
     }
 
@@ -334,7 +335,8 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             destAmount,
             params.feeMode,
             params.feeBps,
-            params.platformWallet
+            params.platformWallet,
+            params.extraArgs
         );
     }
 
@@ -426,13 +428,15 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             abi.encodePacked(params.rateMode)
         );
 
-        uint256 actualDebtPaid = debt.sub(
-            ILending(params.lendingContract).getUserDebtCurrent(
-                params.tradePath[params.tradePath.length - 1],
-                msg.sender
-            )
-        );
-        require(actualDebtPaid >= actualPayAmount, "low paid amount");
+        {
+            uint256 actualDebtPaid = debt.sub(
+                ILending(params.lendingContract).getUserDebtCurrent(
+                    params.tradePath[params.tradePath.length - 1],
+                    msg.sender
+                )
+            );
+            require(actualDebtPaid >= actualPayAmount, "low paid amount");
+        }
 
         emit SwapAndRepay(
             msg.sender,
@@ -444,7 +448,8 @@ contract SmartWalletImplementation is SmartWalletStorage, ISmartWalletImplementa
             actualPayAmount,
             params.feeMode,
             params.feeBps,
-            params.platformWallet
+            params.platformWallet,
+            params.extraArgs
         );
     }
 

--- a/contracts/interfaces/IDMMFactory.sol
+++ b/contracts/interfaces/IDMMFactory.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.7.6;
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IDMMFactory {
+    function createPool(
+        IERC20 tokenA,
+        IERC20 tokenB,
+        uint32 ampBps
+    ) external returns (address pool);
+
+    function getPools(IERC20 token0, IERC20 token1)
+        external
+        view
+        returns (address[] memory _tokenPools);
+}

--- a/contracts/interfaces/IDMMPool.sol
+++ b/contracts/interfaces/IDMMPool.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.7.6;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./IDMMFactory.sol";
+
+interface IDMMPool {
+    function mint(address to) external returns (uint256 liquidity);
+
+    function burn(address to) external returns (uint256 amount0, uint256 amount1);
+
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+
+    function sync() external;
+
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1);
+
+    function getTradeInfo()
+        external
+        view
+        returns (
+            uint112 _vReserve0,
+            uint112 _vReserve1,
+            uint112 reserve0,
+            uint112 reserve1,
+            uint256 feeInPrecision
+        );
+
+    function token0() external view returns (IERC20);
+
+    function token1() external view returns (IERC20);
+
+    function ampBps() external view returns (uint32);
+
+    function factory() external view returns (IDMMFactory);
+
+    function kLast() external view returns (uint256);
+}

--- a/contracts/interfaces/IDMMRouter.sol
+++ b/contracts/interfaces/IDMMRouter.sol
@@ -2,19 +2,7 @@ pragma solidity 0.7.6;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IWeth.sol";
-
-interface IDMMFactory {
-    function createPool(
-        IERC20 tokenA,
-        IERC20 tokenB,
-        uint32 ampBps
-    ) external returns (address pool);
-
-    function getPools(IERC20 token0, IERC20 token1)
-        external
-        view
-        returns (address[] memory _tokenPools);
-}
+import "./IDMMFactory.sol";
 
 interface IDMMRouter {
     function factory() external pure returns (address);

--- a/contracts/interfaces/ISmartWalletImplementation.sol
+++ b/contracts/interfaces/ISmartWalletImplementation.sol
@@ -18,8 +18,7 @@ interface ISmartWalletImplementation {
         uint256 destAmount,
         FeeMode feeMode,
         uint256 feeBps,
-        address platformWallet,
-        bytes extraArgs
+        address platformWallet
     );
 
     event SwapAndDeposit(
@@ -31,8 +30,7 @@ interface ISmartWalletImplementation {
         uint256 destAmount,
         FeeMode feeMode,
         uint256 feeBps,
-        address platformWallet,
-        bytes extraArgs
+        address platformWallet
     );
 
     event WithdrawFromLending(
@@ -54,8 +52,7 @@ interface ISmartWalletImplementation {
         uint256 payAmount,
         FeeMode feeMode,
         uint256 feeBps,
-        address platformWallet,
-        bytes extraArgs
+        address platformWallet
     );
 
     /// @param swapContract swap contract

--- a/contracts/interfaces/ISmartWalletImplementation.sol
+++ b/contracts/interfaces/ISmartWalletImplementation.sol
@@ -74,6 +74,15 @@ interface ISmartWalletImplementation {
         view
         returns (uint256 destAmount, uint256 expectedRate);
 
+    function getExpectedReturnWithImpact(GetExpectedReturnParams calldata params)
+        external
+        view
+        returns (
+            uint256 destAmount,
+            uint256 expectedRate,
+            uint256 priceImpact
+        ); // in BPS
+
     struct GetExpectedInParams {
         address payable swapContract;
         uint256 destAmount;
@@ -87,6 +96,15 @@ interface ISmartWalletImplementation {
         external
         view
         returns (uint256 srcAmount, uint256 expectedRate);
+
+    function getExpectedInWithImpact(GetExpectedInParams calldata params)
+        external
+        view
+        returns (
+            uint256 srcAmount,
+            uint256 expectedRate,
+            uint256 priceImpact
+        );
 
     /// @param swapContract swap contract
     /// @param srcAmount amount of src token

--- a/contracts/interfaces/ISmartWalletImplementation.sol
+++ b/contracts/interfaces/ISmartWalletImplementation.sol
@@ -18,7 +18,8 @@ interface ISmartWalletImplementation {
         uint256 destAmount,
         FeeMode feeMode,
         uint256 feeBps,
-        address platformWallet
+        address platformWallet,
+        bytes extraArgs
     );
 
     event SwapAndDeposit(
@@ -30,7 +31,8 @@ interface ISmartWalletImplementation {
         uint256 destAmount,
         FeeMode feeMode,
         uint256 feeBps,
-        address platformWallet
+        address platformWallet,
+        bytes extraArgs
     );
 
     event WithdrawFromLending(
@@ -52,7 +54,8 @@ interface ISmartWalletImplementation {
         uint256 payAmount,
         FeeMode feeMode,
         uint256 feeBps,
-        address platformWallet
+        address platformWallet,
+        bytes extraArgs
     );
 
     /// @param swapContract swap contract

--- a/contracts/libraries/UniswapV2Library.sol
+++ b/contracts/libraries/UniswapV2Library.sol
@@ -1,0 +1,118 @@
+pragma solidity >=0.5.0;
+
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+library UniswapV2Library {
+    using SafeMath for uint256;
+
+    // returns sorted token addresses, used to handle return values from pairs sorted in this order
+    function sortTokens(address tokenA, address tokenB)
+        internal
+        pure
+        returns (address token0, address token1)
+    {
+        require(tokenA != tokenB, "UniswapV2Library: IDENTICAL_ADDRESSES");
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        require(token0 != address(0), "UniswapV2Library: ZERO_ADDRESS");
+    }
+
+    // calculates the CREATE2 address for a pair without making any external calls
+    function pairFor(
+        address factory,
+        address tokenA,
+        address tokenB
+    ) internal view returns (address pair) {
+        return IUniswapV2Factory(factory).getPair(tokenA, tokenB);
+        /*
+        (address token0, address token1) = sortTokens(tokenA, tokenB);
+        pair = address(uint(keccak256(abi.encodePacked(
+                hex'ff',
+                factory,
+                keccak256(abi.encodePacked(token0, token1)),
+                hex'96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' // init code hash
+            ))));
+           */
+    }
+
+    // fetches and sorts the reserves for a pair
+    function getReserves(
+        address factory,
+        address tokenA,
+        address tokenB
+    ) internal view returns (uint256 reserveA, uint256 reserveB) {
+        (address token0, ) = sortTokens(tokenA, tokenB);
+        (uint256 reserve0, uint256 reserve1, ) = IUniswapV2Pair(pairFor(factory, tokenA, tokenB))
+        .getReserves();
+        (reserveA, reserveB) = tokenA == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+    }
+
+    // given some amount of an asset and pair reserves, returns an equivalent amount of the other asset
+    function quote(
+        uint256 amountA,
+        uint256 reserveA,
+        uint256 reserveB
+    ) internal pure returns (uint256 amountB) {
+        require(amountA > 0, "UniswapV2Library: INSUFFICIENT_AMOUNT");
+        require(reserveA > 0 && reserveB > 0, "UniswapV2Library: INSUFFICIENT_LIQUIDITY");
+        amountB = amountA.mul(reserveB) / reserveA;
+    }
+
+    // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) internal pure returns (uint256 amountOut) {
+        require(amountIn > 0, "UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT");
+        require(reserveIn > 0 && reserveOut > 0, "UniswapV2Library: INSUFFICIENT_LIQUIDITY");
+        uint256 amountInWithFee = amountIn.mul(997);
+        uint256 numerator = amountInWithFee.mul(reserveOut);
+        uint256 denominator = reserveIn.mul(1000).add(amountInWithFee);
+        amountOut = numerator / denominator;
+    }
+
+    // given an output amount of an asset and pair reserves, returns a required input amount of the other asset
+    function getAmountIn(
+        uint256 amountOut,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) internal pure returns (uint256 amountIn) {
+        require(amountOut > 0, "UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT");
+        require(reserveIn > 0 && reserveOut > 0, "UniswapV2Library: INSUFFICIENT_LIQUIDITY");
+        uint256 numerator = reserveIn.mul(amountOut).mul(1000);
+        uint256 denominator = reserveOut.sub(amountOut).mul(997);
+        amountIn = (numerator / denominator).add(1);
+    }
+
+    // performs chained getAmountOut calculations on any number of pairs
+    function getAmountsOut(
+        address factory,
+        uint256 amountIn,
+        address[] memory path
+    ) internal view returns (uint256[] memory amounts) {
+        require(path.length >= 2, "UniswapV2Library: INVALID_PATH");
+        amounts = new uint256[](path.length);
+        amounts[0] = amountIn;
+        for (uint256 i; i < path.length - 1; i++) {
+            (uint256 reserveIn, uint256 reserveOut) = getReserves(factory, path[i], path[i + 1]);
+            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    // performs chained getAmountIn calculations on any number of pairs
+    function getAmountsIn(
+        address factory,
+        uint256 amountOut,
+        address[] memory path
+    ) internal view returns (uint256[] memory amounts) {
+        require(path.length >= 2, "UniswapV2Library: INVALID_PATH");
+        amounts = new uint256[](path.length);
+        amounts[amounts.length - 1] = amountOut;
+        for (uint256 i = path.length - 1; i > 0; i--) {
+            (uint256 reserveIn, uint256 reserveOut) = getReserves(factory, path[i - 1], path[i]);
+            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
+        }
+    }
+}

--- a/contracts/swap/ISwap.sol
+++ b/contracts/swap/ISwap.sol
@@ -15,6 +15,11 @@ interface ISwap {
         view
         returns (uint256 destAmount);
 
+    function getExpectedReturnWithImpact(GetExpectedReturnParams calldata params)
+        external
+        view
+        returns (uint256 destAmount, uint256 priceImpact);
+
     struct GetExpectedInParams {
         uint256 destAmount;
         address[] tradePath;
@@ -26,6 +31,11 @@ interface ISwap {
         external
         view
         returns (uint256 srcAmount);
+
+    function getExpectedInWithImpact(GetExpectedInParams calldata params)
+        external
+        view
+        returns (uint256 srcAmount, uint256 priceImpact);
 
     struct SwapParams {
         uint256 srcAmount;

--- a/contracts/swap/KyberProxy.sol
+++ b/contracts/swap/KyberProxy.sol
@@ -52,12 +52,46 @@ contract KyberProxy is BaseSwap {
         );
     }
 
+    function getExpectedReturnWithImpact(GetExpectedReturnParams calldata params)
+        external
+        view
+        override
+        onlyProxyContract
+        returns (uint256 destAmount, uint256 priceImpact)
+    {
+        require(params.tradePath.length == 2, "kyber_invalidTradepath");
+        uint256 expectedRate = kyberProxy.getExpectedRateAfterFee(
+            IERC20Ext(params.tradePath[0]),
+            IERC20Ext(params.tradePath[1]),
+            params.srcAmount,
+            params.feeBps,
+            params.extraArgs
+        );
+        destAmount = calcDestAmount(
+            IERC20Ext(params.tradePath[0]),
+            IERC20Ext(params.tradePath[1]),
+            params.srcAmount,
+            expectedRate
+        );
+        priceImpact = 0;
+    }
+
     function getExpectedIn(GetExpectedInParams calldata params)
         external
         view
         override
         onlyProxyContract
         returns (uint256 srcAmount)
+    {
+        require(false, "getExpectedIn_notSupported");
+    }
+
+    function getExpectedInWithImpact(GetExpectedInParams calldata params)
+        external
+        view
+        override
+        onlyProxyContract
+        returns (uint256 srcAmount, uint256 priceImpact)
     {
         require(false, "getExpectedIn_notSupported");
     }

--- a/contracts/swap/OneInch.sol
+++ b/contracts/swap/OneInch.sol
@@ -36,12 +36,32 @@ contract OneInch is BaseSwap {
         require(false, "getExpectedReturn_notSupported");
     }
 
+    function getExpectedReturnWithImpact(GetExpectedReturnParams calldata params)
+        external
+        view
+        override
+        onlyProxyContract
+        returns (uint256 destAmount, uint256 priceImpact)
+    {
+        require(false, "getExpectedReturn_notSupported");
+    }
+
     function getExpectedIn(GetExpectedInParams calldata params)
         external
         view
         override
         onlyProxyContract
         returns (uint256 srcAmount)
+    {
+        require(false, "getExpectedIn_notSupported");
+    }
+
+    function getExpectedInWithImpact(GetExpectedInParams calldata params)
+        external
+        view
+        override
+        onlyProxyContract
+        returns (uint256 srcAmount, uint256 priceImpact)
     {
         require(false, "getExpectedIn_notSupported");
     }

--- a/scripts/deployLogic.ts
+++ b/scripts/deployLogic.ts
@@ -27,7 +27,7 @@ import {EthersAdapter} from '@gnosis.pm/safe-core-sdk';
 import {OperationType} from '@gnosis.pm/safe-core-sdk-types';
 import Safe from '@gnosis.pm/safe-core-sdk';
 
-const gasLimit = 200000;
+const gasLimit = 300000;
 
 const networkConfig = NetworkConfig[network.name];
 if (!networkConfig) {
@@ -366,7 +366,7 @@ async function deployContract(
     // if (autoVerify) {
     try {
       log(3, '>> sleep first, wait for contract data to be propagated');
-      await sleep(5000);
+      await sleep(2000);
       log(3, '>> start verifying');
       await run('verify:verify', {
         address: contract.address,


### PR DESCRIPTION
Implement price impact calculation by comparing `rate` with current price according to current pools.
Also improve UniV3 with its own implementation of getAmountIn, instead of relying on default binary-search. This should greatly improve UniV3 performance